### PR TITLE
Update permission check to support new version of Kirby

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Currently only auto-suggests existing pages, not files (but supports file copyin
 ### Requirements
 
 -	PHP 5.4.0+
--	Kirby 2.3.0+
+-	Kirby 2.4.0+
 
 ### Kirby CLI (untested)
 

--- a/copy-files.php
+++ b/copy-files.php
@@ -20,7 +20,7 @@ panel()->routes([[
   'method' => 'POST',
   'action' => function() {
     $user = site()->user()->current();
-    if (!$user || (!$user->hasPermission('panel.page.create') && !$user->isAdmin())) {
+    if (!$user || (!$user->permission('panel.page.create') && !$user->isAdmin())) {
       return Response::error("Must be authenticated as user with page creation permissions");
     }
 


### PR DESCRIPTION
Kirby 2.4.0+ uses the method "permission" instead of the previous "hasPermission".

https://getkirby.com/docs/cheatsheet/user/permission